### PR TITLE
Fix publish for TS users

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,0 @@
-
-module.exports = require('./build/OpenAPI');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@tinkoff/invest-openapi-js-sdk",
   "version": "1.0.5",
   "description": "Tinkoff Invest OpenAPI Client",
-  "main": "index.js",
+  "main": "build/openApi.js",
   "directories": {
     "example": "example"
   },


### PR DESCRIPTION
This fix will work fine with JS users and fixes the impossibility of use for TS users.
Now tsc couldn't find declarations due to `index.ts` doesn't have them.

```
Could not find a declaration file for module '@tinkoff/invest-openapi-js-sdk'. '.../node_modules/@tinkoff/invest-openapi-js-sdk/index.js' implicitly has an 'any' type.
  Try `npm install @types/tinkoff__invest-openapi-js-sdk` if it exists or add a new declaration (.d.ts) file containing `declare module '@tinkoff/invest-openapi-js-sdk';`ts(7016)
```