### PR TITLE
Исправлен неверный регистр скомпилированного файла

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ export default [
   {
     input: './src/OpenAPI.ts',
     output: {
-      file: 'build/OpenApi.js',
+      file: 'build/OpenAPI.js',
       format: 'cjs',
     },
     plugins: [typescript()],


### PR DESCRIPTION
Неверный регистр вызывал проблемы при подключении модуля на регистро-зависимых ФС.

Этот PR исправляет проблему, описанную в #8.