### PR TITLE
broker account id parameter added

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,6 @@
-[@tinkoff/invest-openapi-js-sdk - v1.2.7](README.md) › [Globals](globals.md)
+[@tinkoff/invest-openapi-js-sdk - v1.2.12](README.md) › [Globals](globals.md)
 
-# @tinkoff/invest-openapi-js-sdk - v1.2.7
+# @tinkoff/invest-openapi-js-sdk - v1.2.12
 
 # Trading Open API - JS SDK
 
@@ -55,7 +55,7 @@ const api = new OpenAPI({ apiURL, secretToken, socketURL });
 
 Для использования _Sandbox_ необходимо передать в apiURL и в secretToken url
 эндпоинта с апи sandbox'а и токен для песочницы.
-Более подробнов [документации](https://tinkoffcreditsystems.github.io/invest-openapi/env/)
+Более подробно в [документации](https://tinkoffcreditsystems.github.io/invest-openapi/env/)
 
 ```typescript
 await api.sandboxClear(); // очищаем песочницу 
@@ -65,3 +65,6 @@ await api.instrumentPortfolio({ figi }); // В портфеле ничего н�
 await api.limitOrder({ operation: 'Buy', figi, lots: 1, price: 100 }); // Покупаем AAPL
 await api.instrumentPortfolio({ figi }); // Сделка прошла моментально
 ```
+## Ограничения
+
+На данный момент доступно только 6 TCP соединений на аккаунт

--- a/doc/classes/openapi.md
+++ b/doc/classes/openapi.md
@@ -21,6 +21,7 @@
 * [candlesGet](openapi.md#candlesget)
 * [currencies](openapi.md#currencies)
 * [etfs](openapi.md#etfs)
+* [getCurrentAccountId](openapi.md#getcurrentaccountid)
 * [instrumentInfo](openapi.md#instrumentinfo)
 * [instrumentPortfolio](openapi.md#instrumentportfolio)
 * [limitOrder](openapi.md#limitorder)
@@ -35,6 +36,7 @@
 * [search](openapi.md#search)
 * [searchOne](openapi.md#searchone)
 * [setCurrenciesBalance](openapi.md#setcurrenciesbalance)
+* [setCurrentAccountId](openapi.md#setcurrentaccountid)
 * [setPositionBalance](openapi.md#setpositionbalance)
 * [stocks](openapi.md#stocks)
 
@@ -51,7 +53,8 @@
 Name | Type | Description |
 ------ | ------ | ------ |
 `apiURL` | string | REST api url см [документацию](https://tinkoffcreditsystems.github.io/invest-openapi/env/) |
-`secretToken` | string | токен доступа см [получение токена доступа](https://tinkoffcreditsystems.github.io/invest-openapi/auth/)   |
+`brokerAccountId` | undefined &#124; string | номер счета (по умолчанию - Тинькофф)  |
+`secretToken` | string | токен доступа см [получение токена доступа](https://tinkoffcreditsystems.github.io/invest-openapi/auth/) |
 `socketURL` | string | Streaming api url см [документацию](https://tinkoffcreditsystems.github.io/invest-openapi/env/) |
 
 **Returns:** *[OpenAPI](openapi.md)*
@@ -90,8 +93,7 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`brokerAccountId` | undefined &#124; string | номер счета (по умолчанию - Тинькофф)  |
-`orderId` | string | идентифткатор заявки |
+`orderId` | string | идентифткатор заявки  |
 
 **Returns:** *Promise‹void›*
 
@@ -173,6 +175,16 @@ ___
 
 ___
 
+###  getCurrentAccountId
+
+▸ **getCurrentAccountId**(): *string | undefined*
+
+Метод возвращает текущий номер счета (*undefined* - значение по умолчанию для счета Тинькофф).
+
+**Returns:** *string | undefined*
+
+___
+
 ###  instrumentInfo
 
 ▸ **instrumentInfo**(`__namedParameters`: object, `cb`: log): *(Anonymous function)*
@@ -201,7 +213,7 @@ ___
 
 ###  instrumentPortfolio
 
-▸ **instrumentPortfolio**(`params`: [InstrumentId](../globals.md#instrumentid) & [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹[PortfolioPosition](../globals.md#portfolioposition) | null›*
+▸ **instrumentPortfolio**(`params`: [InstrumentId](../globals.md#instrumentid)): *Promise‹[PortfolioPosition](../globals.md#portfolioposition) | null›*
 
 Метод для получение данных по инструменту в портфеле
 
@@ -209,7 +221,7 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`params` | [InstrumentId](../globals.md#instrumentid) & [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
+`params` | [InstrumentId](../globals.md#instrumentid) | см. описание типа  |
 
 **Returns:** *Promise‹[PortfolioPosition](../globals.md#portfolioposition) | null›*
 
@@ -227,11 +239,10 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`brokerAccountId` | undefined &#124; string | номер счета (по умолчанию - Тинькофф)  |
 `figi` | string | идентификатор инструмента |
 `lots` | number | количество лотов для заявки |
 `operation` | "Buy" &#124; "Sell" | тип заявки |
-`price` | number | цена лимитной заявки |
+`price` | number | цена лимитной заявки  |
 
 **Returns:** *Promise‹[PlacedLimitOrder](../globals.md#placedlimitorder)›*
 
@@ -249,7 +260,6 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`brokerAccountId` | undefined &#124; string | номер счета (по умолчанию - Тинькофф)  |
 `figi` | string | идентификатор инструмента |
 `lots` | number | количество лотов для заявки |
 `operation` | "Buy" &#124; "Sell" | тип заявки |
@@ -270,8 +280,7 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`brokerAccountId` | undefined &#124; string | номер счета (по умолчанию - Тинькофф)  |
-`figi` | undefined &#124; string | Figi-идентификатор инструмента |
+`figi` | undefined &#124; string | Figi-идентификатор инструмента  |
 `from` | string | Начало временного промежутка в формате ISO 8601 |
 `to` | string | Конец временного промежутка в формате ISO 8601 |
 
@@ -341,15 +350,9 @@ ___
 
 ###  orders
 
-▸ **orders**(`params?`: [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹[Order](../globals.md#order)[]›*
+▸ **orders**(): *Promise‹[Order](../globals.md#order)[]›*
 
 Метод для получения всех активных заявок
-
-**Parameters:**
-
-Name | Type | Description |
------- | ------ | ------ |
-`params?` | [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
 
 **Returns:** *Promise‹[Order](../globals.md#order)[]›*
 
@@ -357,15 +360,9 @@ ___
 
 ###  portfolio
 
-▸ **portfolio**(`params?`: [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹[Portfolio](../globals.md#portfolio)›*
+▸ **portfolio**(): *Promise‹[Portfolio](../globals.md#portfolio)›*
 
 Метод для получение портфеля цб
-
-**Parameters:**
-
-Name | Type | Description |
------- | ------ | ------ |
-`params?` | [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
 
 **Returns:** *Promise‹[Portfolio](../globals.md#portfolio)›*
 
@@ -373,15 +370,9 @@ ___
 
 ###  portfolioCurrencies
 
-▸ **portfolioCurrencies**(`params?`: [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹[Currencies](../globals.md#currencies)›*
+▸ **portfolioCurrencies**(): *Promise‹[Currencies](../globals.md#currencies)›*
 
 Метод для получения валютных активов клиента
-
-**Parameters:**
-
-Name | Type | Description |
------- | ------ | ------ |
-`params?` | [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
 
 **Returns:** *Promise‹[Currencies](../globals.md#currencies)›*
 
@@ -389,15 +380,9 @@ ___
 
 ###  sandboxClear
 
-▸ **sandboxClear**(`params?`: [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹any›*
+▸ **sandboxClear**(): *Promise‹any›*
 
 Метод для очистки песочницы
-
-**Parameters:**
-
-Name | Type | Description |
------- | ------ | ------ |
-`params?` | [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
 
 **Returns:** *Promise‹any›*
 
@@ -437,7 +422,7 @@ ___
 
 ###  setCurrenciesBalance
 
-▸ **setCurrenciesBalance**(`params`: [SandboxSetCurrencyBalanceRequest](../globals.md#sandboxsetcurrencybalancerequest) & [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹void›*
+▸ **setCurrenciesBalance**(`params`: [SandboxSetCurrencyBalanceRequest](../globals.md#sandboxsetcurrencybalancerequest)): *Promise‹void›*
 
 Метод для задания баланса по валютам
 
@@ -445,15 +430,31 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`params` | [SandboxSetCurrencyBalanceRequest](../globals.md#sandboxsetcurrencybalancerequest) & [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
+`params` | [SandboxSetCurrencyBalanceRequest](../globals.md#sandboxsetcurrencybalancerequest) | см. описание типа  |
 
 **Returns:** *Promise‹void›*
 
 ___
 
+###  setCurrentAccountId
+
+▸ **setCurrentAccountId**(`brokerAccountId`: string | undefined): *void*
+
+Метод для сохранения номера счета по умолчанию.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`brokerAccountId` | string &#124; undefined | Номер счета. Для счета Тинькофф можно также передать значение *undefined*.  |
+
+**Returns:** *void*
+
+___
+
 ###  setPositionBalance
 
-▸ **setPositionBalance**(`params`: [SandboxSetPositionBalanceRequest](../globals.md#sandboxsetpositionbalancerequest) & [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹void›*
+▸ **setPositionBalance**(`params`: [SandboxSetPositionBalanceRequest](../globals.md#sandboxsetpositionbalancerequest)): *Promise‹void›*
 
 Метод для задания баланса по бумагам
 
@@ -461,7 +462,7 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`params` | [SandboxSetPositionBalanceRequest](../globals.md#sandboxsetpositionbalancerequest) & [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
+`params` | [SandboxSetPositionBalanceRequest](../globals.md#sandboxsetpositionbalancerequest) | см. описание типа  |
 
 **Returns:** *Promise‹void›*
 

--- a/doc/classes/openapi.md
+++ b/doc/classes/openapi.md
@@ -1,4 +1,4 @@
-[@tinkoff/invest-openapi-js-sdk - v1.2.7](../README.md) › [Globals](../globals.md) › [OpenAPI](openapi.md)
+[@tinkoff/invest-openapi-js-sdk - v1.2.12](../README.md) › [Globals](../globals.md) › [OpenAPI](openapi.md)
 
 # Class: OpenAPI
 
@@ -14,6 +14,7 @@
 
 ### Methods
 
+* [accounts](openapi.md#accounts)
 * [bonds](openapi.md#bonds)
 * [cancelOrder](openapi.md#cancelorder)
 * [candle](openapi.md#candle)
@@ -57,6 +58,16 @@ Name | Type | Description |
 
 ## Methods
 
+###  accounts
+
+▸ **accounts**(): *Promise‹[UserAccounts](../globals.md#useraccounts)›*
+
+Метод для получения брокерских счетов клиента
+
+**Returns:** *Promise‹[UserAccounts](../globals.md#useraccounts)›*
+
+___
+
 ###  bonds
 
 ▸ **bonds**(): *Promise‹[MarketInstrumentList](../globals.md#marketinstrumentlist)›*
@@ -79,7 +90,8 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`orderId` | string | идентифткатор заявки  |
+`brokerAccountId` | undefined &#124; string | номер счета (по умолчанию - Тинькофф)  |
+`orderId` | string | идентифткатор заявки |
 
 **Returns:** *Promise‹void›*
 
@@ -189,15 +201,15 @@ ___
 
 ###  instrumentPortfolio
 
-▸ **instrumentPortfolio**(`params`: [InstrumentId](../globals.md#instrumentid)): *Promise‹[PortfolioPosition](../globals.md#portfolioposition) | null›*
+▸ **instrumentPortfolio**(`params`: [InstrumentId](../globals.md#instrumentid) & [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹[PortfolioPosition](../globals.md#portfolioposition) | null›*
 
 Метод для получение данных по инструменту в портфеле
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`params` | [InstrumentId](../globals.md#instrumentid) |
+Name | Type | Description |
+------ | ------ | ------ |
+`params` | [InstrumentId](../globals.md#instrumentid) & [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
 
 **Returns:** *Promise‹[PortfolioPosition](../globals.md#portfolioposition) | null›*
 
@@ -215,10 +227,11 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
+`brokerAccountId` | undefined &#124; string | номер счета (по умолчанию - Тинькофф)  |
 `figi` | string | идентификатор инструмента |
 `lots` | number | количество лотов для заявки |
 `operation` | "Buy" &#124; "Sell" | тип заявки |
-`price` | number | цена лимитной заявки  |
+`price` | number | цена лимитной заявки |
 
 **Returns:** *Promise‹[PlacedLimitOrder](../globals.md#placedlimitorder)›*
 
@@ -236,6 +249,7 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
+`brokerAccountId` | undefined &#124; string | номер счета (по умолчанию - Тинькофф)  |
 `figi` | string | идентификатор инструмента |
 `lots` | number | количество лотов для заявки |
 `operation` | "Buy" &#124; "Sell" | тип заявки |
@@ -256,7 +270,8 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`figi` | string | Figi-идентификатор инструмента  |
+`brokerAccountId` | undefined &#124; string | номер счета (по умолчанию - Тинькофф)  |
+`figi` | undefined &#124; string | Figi-идентификатор инструмента |
 `from` | string | Начало временного промежутка в формате ISO 8601 |
 `to` | string | Конец временного промежутка в формате ISO 8601 |
 
@@ -326,9 +341,15 @@ ___
 
 ###  orders
 
-▸ **orders**(): *Promise‹[Order](../globals.md#order)[]›*
+▸ **orders**(`params?`: [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹[Order](../globals.md#order)[]›*
 
 Метод для получения всех активных заявок
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`params?` | [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
 
 **Returns:** *Promise‹[Order](../globals.md#order)[]›*
 
@@ -336,9 +357,15 @@ ___
 
 ###  portfolio
 
-▸ **portfolio**(): *Promise‹[Portfolio](../globals.md#portfolio)›*
+▸ **portfolio**(`params?`: [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹[Portfolio](../globals.md#portfolio)›*
 
 Метод для получение портфеля цб
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`params?` | [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
 
 **Returns:** *Promise‹[Portfolio](../globals.md#portfolio)›*
 
@@ -346,9 +373,15 @@ ___
 
 ###  portfolioCurrencies
 
-▸ **portfolioCurrencies**(): *Promise‹[Currencies](../globals.md#currencies)›*
+▸ **portfolioCurrencies**(`params?`: [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹[Currencies](../globals.md#currencies)›*
 
 Метод для получения валютных активов клиента
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`params?` | [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
 
 **Returns:** *Promise‹[Currencies](../globals.md#currencies)›*
 
@@ -356,9 +389,15 @@ ___
 
 ###  sandboxClear
 
-▸ **sandboxClear**(): *Promise‹any›*
+▸ **sandboxClear**(`params?`: [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹any›*
 
 Метод для очистки песочницы
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`params?` | [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
 
 **Returns:** *Promise‹any›*
 
@@ -398,7 +437,7 @@ ___
 
 ###  setCurrenciesBalance
 
-▸ **setCurrenciesBalance**(`params`: [SandboxSetCurrencyBalanceRequest](../globals.md#sandboxsetcurrencybalancerequest)): *Promise‹void›*
+▸ **setCurrenciesBalance**(`params`: [SandboxSetCurrencyBalanceRequest](../globals.md#sandboxsetcurrencybalancerequest) & [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹void›*
 
 Метод для задания баланса по валютам
 
@@ -406,7 +445,7 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`params` | [SandboxSetCurrencyBalanceRequest](../globals.md#sandboxsetcurrencybalancerequest) | см. описание типа  |
+`params` | [SandboxSetCurrencyBalanceRequest](../globals.md#sandboxsetcurrencybalancerequest) & [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
 
 **Returns:** *Promise‹void›*
 
@@ -414,7 +453,7 @@ ___
 
 ###  setPositionBalance
 
-▸ **setPositionBalance**(`params`: [SandboxSetPositionBalanceRequest](../globals.md#sandboxsetpositionbalancerequest)): *Promise‹void›*
+▸ **setPositionBalance**(`params`: [SandboxSetPositionBalanceRequest](../globals.md#sandboxsetpositionbalancerequest) & [BrokerAccountId](../globals.md#brokeraccountid)): *Promise‹void›*
 
 Метод для задания баланса по бумагам
 
@@ -422,7 +461,7 @@ ___
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`params` | [SandboxSetPositionBalanceRequest](../globals.md#sandboxsetpositionbalancerequest) | см. описание типа  |
+`params` | [SandboxSetPositionBalanceRequest](../globals.md#sandboxsetpositionbalancerequest) & [BrokerAccountId](../globals.md#brokeraccountid) | см. описание типа  |
 
 **Returns:** *Promise‹void›*
 

--- a/doc/globals.md
+++ b/doc/globals.md
@@ -10,7 +10,6 @@
 
 ### Type aliases
 
-* [BrokerAccountId](globals.md#brokeraccountid)
 * [BrokerAccountType](globals.md#brokeraccounttype)
 * [Candle](globals.md#candle)
 * [CandleResolution](globals.md#candleresolution)
@@ -83,16 +82,6 @@
 * [omitUndef](globals.md#const-omitundef)
 
 ## Type aliases
-
-###  BrokerAccountId
-
-Ƭ **BrokerAccountId**: *object*
-
-#### Type declaration:
-
-* **brokerAccountId**? : *undefined | string*
-
-___
 
 ###  BrokerAccountType
 
@@ -458,6 +447,8 @@ ___
 #### Type declaration:
 
 * **apiURL**: *string*
+
+* **brokerAccountId**? : *undefined | string*
 
 * **secretToken**: *string*
 

--- a/doc/globals.md
+++ b/doc/globals.md
@@ -1,6 +1,6 @@
-[@tinkoff/invest-openapi-js-sdk - v1.2.7](README.md) › [Globals](globals.md)
+[@tinkoff/invest-openapi-js-sdk - v1.2.12](README.md) › [Globals](globals.md)
 
-# @tinkoff/invest-openapi-js-sdk - v1.2.7
+# @tinkoff/invest-openapi-js-sdk - v1.2.12
 
 ## Index
 
@@ -10,6 +10,7 @@
 
 ### Type aliases
 
+* [BrokerAccountId](globals.md#brokeraccountid)
 * [BrokerAccountType](globals.md#brokeraccounttype)
 * [Candle](globals.md#candle)
 * [CandleResolution](globals.md#candleresolution)
@@ -79,8 +80,19 @@
 ### Functions
 
 * [getQueryString](globals.md#getquerystring)
+* [omitUndef](globals.md#const-omitundef)
 
 ## Type aliases
+
+###  BrokerAccountId
+
+Ƭ **BrokerAccountId**: *object*
+
+#### Type declaration:
+
+* **brokerAccountId**? : *undefined | string*
+
+___
 
 ###  BrokerAccountType
 
@@ -643,6 +655,8 @@ ___
 
 #### Type declaration:
 
+* **asks**: *Array‹[number, number]›*
+
 * **bids**: *Array‹[number, number]›*
 
 * **depth**: *[Depth](globals.md#depth)*
@@ -787,9 +801,11 @@ ___
 
 #### Type declaration:
 
+* **body**? : *B*
+
 * **method**? : *[HttpMethod](globals.md#httpmethod)*
 
-* **params**? : *P*
+* **query**? : *Q*
 
 ___
 
@@ -956,3 +972,17 @@ Name | Type |
 `params` | Record‹string, string &#124; number› |
 
 **Returns:** *string*
+
+___
+
+### `Const` omitUndef
+
+▸ **omitUndef**(`x`: object): *any*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`x` | object |
+
+**Returns:** *any*

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,3 @@ export type LimitOrderParams = {
 export type FIGI = {
     figi: string;
 };
-
-export type BrokerAccountId = {
-    brokerAccountId?: string;
-};

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,4 +46,8 @@ export type LimitOrderParams = {
 
 export type FIGI = {
     figi: string;
-}
+};
+
+export type BrokerAccountId = {
+    brokerAccountId?: string;
+};


### PR DESCRIPTION
#27 

1. Добавлен метод `accounts` для получения списка аккаунтов пользователя.
2. Необязательный параметр `brokerAccountId` добавлен во все реализованные методы подобно реализации в java-sdk. Обратная совместимость не сломана. 
3. Приватный метод `makeRequest` обновлен для разделения get и post-параметров, чтобы была единая точка ответственности за формирование запроса. 
4. Обновлена документация.

В конструктор не стал добавлять аккаунт по-умолчанию, т.к. имхо @BusinessDuck прав в обсуждении https://github.com/TinkoffCreditSystems/invest-openapi-js-sdk/pull/44#issuecomment-618964028 и для управления аккаунтами не совсем правильно хранить внутреннее состояние. Тем более, что само api уже устанавливает значение по-умолчанию.