### PR TITLE
exclude deps from builded bundle

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,13 @@
 import typescript from 'rollup-plugin-typescript2';
-import pkg from "./package.json";
+import pkg from './package.json';
 
 export default [
   {
     input: './src/OpenAPI.ts',
+    external: ['isomorphic-fetch', 'ws', 'url', 'events'],
     output: [
-      { file: pkg.main, format: "cjs" },
-      { file: pkg.module, format: "esm" }
+      { file: pkg.main, format: 'cjs' },
+      { file: pkg.module, format: 'esm' },
     ],
     plugins: [typescript()],
   },


### PR DESCRIPTION
Использую sdk с есм и из-за того что в билде есть `module.exports` получаю такую ошибку: 

<img width="455" alt="Снимок экрана 2021-05-04 в 14 18 08" src="https://user-images.githubusercontent.com/6726016/116996360-f7360b80-ace3-11eb-9956-09e4043f3a5c.png">

Это происходит из-за того что ролап включает полифил для `fetch` в сборку, который использует `module.exports`

- убрал все зависимости из бандла, теперь они импортятся 