### PR TITLE
Исправлена ошибка многоразовой подписки на каналы

### DIFF
--- a/src/Streaming.ts
+++ b/src/Streaming.ts
@@ -201,13 +201,14 @@ export default class Streaming extends EventEmitter {
     if (!this._ws) {
       this.connect();
     }
-
+    let eventName = this.getEventName(type, params);
     const message = { event: `${type}:subscribe`, ...params };
-    this.enqueue(message);
-    this._subscribeMessages.push(message);
+    if (!this.listenerCount(eventName)) {
+      this.enqueue(message);
+      this._subscribeMessages.push(message);
+    }
 
     const handler = (x: any) => setImmediate(() => cb(x));
-    let eventName = this.getEventName(type, params);
 
     this.on(eventName, handler);
 


### PR DESCRIPTION
Подписка на каналы никак не контроллируется. На стороне клиента на
один канал можно подписаться несколько раз и каждый раз на сокет-сервер 
отправляется событие подписки. На стороне сокет-сервера это видимо
никак не отслеживается т.к. подписавшись несколько раз на один канал,
сокет-сервер начинает присылать энное количество абсолютно
одинаковых событий. При тестах доходило до 20 одинаковых событий
на канал.

Отписка от канала сделана правильно. Если отписался последний слушатель
канала, то на сокет-сервер отправляется событие отписки.

При подписке  на канал никаких проверок не производиться. Сколько раз
приложение решило подписаться на канал, столько раз на сокет-сервер
отправляется событие подписки.

Для исправление такого поведения, перед подпиской на канал добавлена
проверка количества слушателей канала. Запрос на подписку отправляется
на сокет-сервер только в случае если слушателей нет.